### PR TITLE
Feature on missile destruction

### DIFF
--- a/scripts/scenario_00_basic.lua
+++ b/scripts/scenario_00_basic.lua
@@ -93,6 +93,13 @@ end
 function init()
     -- Spawn a player Atlantis.
     player = PlayerSpaceship():setFaction("Human Navy"):setTemplate("Atlantis")
+    player:onTakingDamage(function(self,instigator, type, freq, sys, shi, dam, hit)
+		string.format("")	--serious proton needs a global context
+		if instigator ~= nil then
+            print(string.format("Degats: type %s freq %i sys %s shi %f dam %f hit %i",type,freq,sys,shi,dam,hit))
+            
+		end
+	end)
 
     enemyList = {}
     friendlyList = {}

--- a/scripts/shipTemplates_Corvette.lua
+++ b/scripts/shipTemplates_Corvette.lua
@@ -26,11 +26,14 @@ template:setBeam(2,100, 180, 1500.0, 6.0, 8)
 template:setTubes(4, 10.0)
 
 -- Base, New name, Damage Multiplier (0 to infinite), Speed
-template:setCustomWeapon("Homing", "Homing_2", 1.5, 200.0, "Emp")
+template:setCustomWeapon("Homing", "Homing_2", 1.5, 200.0, "Emp", 3)
 template:setCustomWeaponColor("Homing_2", 0, 255, 0)
 template:setCustomWeaponMultiple("Homing_2",2,3)
+template:onCustomWeaponDetonation("Homing_2", function(self)
+print "toto"
+end)
 
-template:setCustomWeapon("Homing", "Homing_3", 1.5, 200.0, "Emp")
+template:setCustomWeapon("Homing", "Homing_3", 1.5, 200.0, "Emp", -1)
 template:setCustomWeaponColor("Homing_3", 0, 255, 0)
 template:setCustomWeaponMultiple("Homing_3", 3,2)
 

--- a/scripts/shipTemplates_Corvette.lua
+++ b/scripts/shipTemplates_Corvette.lua
@@ -26,11 +26,14 @@ template:setBeam(2,100, 180, 1500.0, 6.0, 8)
 template:setTubes(4, 10.0)
 
 -- Base, New name, Damage Multiplier (0 to infinite), Speed
-template:setCustomWeapon("Homing", "Homing_2", 1.5, 200.0, "Emp", 3)
+template:setCustomWeapon("Homing", "Homing_2", 1.5, 200.0, "Emp", -1)
 template:setCustomWeaponColor("Homing_2", 0, 255, 0)
 template:setCustomWeaponMultiple("Homing_2",2,3)
-template:onCustomWeaponDetonation("Homing_2", function(self)
-print "toto"
+template:onCustomWeaponDetonation("Homing_2", function(self, typeOfDetonation, hitObject)
+print(typeOfDetonation)
+if typeOfDetonation == "HitShip" then
+    print(hitObject:getCallSign())
+end
 end)
 
 template:setCustomWeapon("Homing", "Homing_3", 1.5, 200.0, "Emp", -1)

--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -56,6 +56,7 @@ GameGlobalInfo::GameGlobalInfo()
     use_nano_repair_crew = true;
     use_long_range_for_relay = true;
     use_complex_radar_signatures = false;
+    hack_efficiency_ratio = 1.0;
     
     gm_control_code = "";
     elapsed_time = 0.0f;
@@ -80,6 +81,7 @@ GameGlobalInfo::GameGlobalInfo()
     registerMemberReplication(&use_nano_repair_crew);
     registerMemberReplication(&use_long_range_for_relay);
     registerMemberReplication(&use_complex_radar_signatures);
+    registerMemberReplication(&hack_efficiency_ratio);
     registerMemberReplication(&gm_control_code);
     registerMemberReplication(&elapsed_time, 0.1);
 

--- a/src/gameGlobalInfo.h
+++ b/src/gameGlobalInfo.h
@@ -96,6 +96,7 @@ public:
     bool use_nano_repair_crew;
     bool use_long_range_for_relay;
     bool use_complex_radar_signatures;
+    float hack_efficiency_ratio;
     string gm_control_code;
     float elapsed_time;
     string scenario;

--- a/src/menus/serverCreationScreen.cpp
+++ b/src/menus/serverCreationScreen.cpp
@@ -42,6 +42,7 @@ ServerCreationScreen::ServerCreationScreen()
     gameGlobalInfo->gm_control_code = PreferencesManager::get("server_config_gm_control_code", "").upper();
     gameGlobalInfo->use_long_range_for_relay = PreferencesManager::get("server_use_long_range_for_relay", "1").toInt();
     gameGlobalInfo->use_complex_radar_signatures = PreferencesManager::get("server_config_use_complex_radar_signatures", "0").toInt();
+    gameGlobalInfo->hack_efficiency_ratio = PreferencesManager::get("hack_efficiency_ratio", "1.0").toFloat();
 
     // Create a two-column layout.
     GuiElement* container = new GuiAutoLayout(this, "", GuiAutoLayout::ELayoutMode::LayoutVerticalColumns);

--- a/src/missileWeaponData.cpp
+++ b/src/missileWeaponData.cpp
@@ -55,7 +55,6 @@ void CustomMissileWeaponRegistry::createMissileWeapon(const EMissileWeapons &iBa
     copyMWD.speed = iSpeed;
     copyMWD.basetype = iBaseType;
     copyMWD.damage_type = iDT;
-    std::cout << "lifet i : " << iLifeTime << " namae : " << iNewName << std::endl;
     if(iLifeTime != -1)
         copyMWD.lifetime = iLifeTime;
     //copyMWD.fire_count = iFireCount;

--- a/src/missileWeaponData.cpp
+++ b/src/missileWeaponData.cpp
@@ -45,7 +45,7 @@ const MissileWeaponData& MissileWeaponData::getDataFor(const string& type)
 }
 
 
-void CustomMissileWeaponRegistry::createMissileWeapon(const EMissileWeapons &iBaseType, const std::string &iNewName, const float &iDamageMultiplier, const float &iSpeed, const EDamageType &iDT)
+void CustomMissileWeaponRegistry::createMissileWeapon(const EMissileWeapons &iBaseType, const std::string &iNewName, const float &iDamageMultiplier, const float &iSpeed, const EDamageType &iDT, const float &iLifeTime)
 {
     if((getCustomMissileWeaponTypes().size()) >= (sizeof(uint32_t) - MW_Count))
         assert(0 && "Taille maximum de custom weapon atteinte");
@@ -55,6 +55,9 @@ void CustomMissileWeaponRegistry::createMissileWeapon(const EMissileWeapons &iBa
     copyMWD.speed = iSpeed;
     copyMWD.basetype = iBaseType;
     copyMWD.damage_type = iDT;
+    std::cout << "lifet i : " << iLifeTime << " namae : " << iNewName << std::endl;
+    if(iLifeTime != -1)
+        copyMWD.lifetime = iLifeTime;
     //copyMWD.fire_count = iFireCount;
     //copyMWD.line_count = iLineCount;
 

--- a/src/missileWeaponData.h
+++ b/src/missileWeaponData.h
@@ -53,6 +53,7 @@ public:
     int fire_count;
     int line_count;
     EDamageType damage_type;
+    ScriptSimpleCallback on_detonation;
 
     static const MissileWeaponData& getDataFor(const EMissileWeapons& type);
     static const MissileWeaponData& getDataFor(const string& type);
@@ -80,7 +81,7 @@ public:
 
     static auto getMissileWeapon (const std::string &iName) -> MissileWeaponData& ;
     static auto getMissileWeaponType (const std::string &iName) -> uint32_t& ;
-    static void createMissileWeapon(const EMissileWeapons &iBaseType, const std::string &iNewName, const float &iDamageMultiplier, const float &iSpeed, const EDamageType &iDT);
+    static void createMissileWeapon(const EMissileWeapons &iBaseType, const std::string &iNewName, const float &iDamageMultiplier, const float &iSpeed, const EDamageType &iDT, const float &iLifeTime);
 
 };
 

--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -105,6 +105,7 @@ REGISTER_SCRIPT_CLASS(ShipTemplate)
     ///3rd param and for second parameter lined fire (number of shots fired simultaneously)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setCustomWeaponMultiple);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setCustomWeaponColor);
+    REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, onCustomWeaponDetonation);
     /// Add an empty room to a ship template.
     /// Rooms are shown on the engineering and damcon screens.
     /// If a system room isn't accessible via other rooms connected by doors, that system
@@ -591,9 +592,9 @@ void ShipTemplate::setCustomWeaponStorage(string weapon, int amount)
 }
 
 
-void ShipTemplate::setCustomWeapon(EMissileWeapons base, string weapon_name, float damage_multiplier, float speed, EDamageType dt)
+void ShipTemplate::setCustomWeapon(EMissileWeapons base, string weapon_name, float damage_multiplier, float speed, EDamageType dt, float lifetime)
 {
-    CustomMissileWeaponRegistry::createMissileWeapon(base, weapon_name, damage_multiplier, speed, dt);
+    CustomMissileWeaponRegistry::createMissileWeapon(base, weapon_name, damage_multiplier, speed, dt, lifetime);
 
 }
 
@@ -606,6 +607,11 @@ void ShipTemplate::setCustomWeaponMultiple(string weapon_name, int fire_count, i
 void ShipTemplate::setCustomWeaponColor(string weapon_name, char color_r, char color_g, char color_b)
 {
     CustomMissileWeaponRegistry::getMissileWeapon(weapon_name).color = sf::Color(color_r, color_g, color_b);
+}
+
+void ShipTemplate::onCustomWeaponDetonation(string weapon_name, ScriptSimpleCallback callback)
+{
+    CustomMissileWeaponRegistry::getMissileWeapon(weapon_name).on_detonation = callback;
 }
 
 void ShipTemplate::addRoom(sf::Vector2i position, sf::Vector2i size)

--- a/src/shipTemplate.cpp
+++ b/src/shipTemplate.cpp
@@ -105,6 +105,12 @@ REGISTER_SCRIPT_CLASS(ShipTemplate)
     ///3rd param and for second parameter lined fire (number of shots fired simultaneously)
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setCustomWeaponMultiple);
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, setCustomWeaponColor);
+    ///Called after a custom missile explodes on a target, or after it ends its life.
+    ///If the target is a ship, the ship is given as third argument
+    ///If it ends life, or if hit an object which is not a spaceship, or destroyed second parameter of
+    ///the calback will be nil
+    ///Two arguments : weapon name, and callback
+    ///Three arguments callback : self (missile) ; Hit, HitShip, Destroyed or Expired ; and ship object (if HitShip), object or nil
     REGISTER_SCRIPT_CLASS_FUNCTION(ShipTemplate, onCustomWeaponDetonation);
     /// Add an empty room to a ship template.
     /// Rooms are shown on the engineering and damcon screens.

--- a/src/shipTemplate.h
+++ b/src/shipTemplate.h
@@ -227,11 +227,12 @@ public:
     void setJumpDriveChargeTime(float time) { jump_drive_charge_time = time; }
 	void setJumpDriveEnergy(float charge) { jump_drive_energy_per_km_charge = charge; }
     void setCloaking(bool enabled);
-    void setCustomWeapon(EMissileWeapons weapon, string  new_name, float damage_multiplier, float speed, EDamageType dt);
+    void setCustomWeapon(EMissileWeapons weapon, string  new_name, float damage_multiplier, float speed, EDamageType dt, float lifetime);
     void setCustomWeaponMultiple(string weapon_name, int fire_count, int line_count);
     void setCustomWeaponColor(string weapon_name, char color_r, char color_g, char color_b);
     void setWeaponStorage(EMissileWeapons weapon, int amount);
     void setCustomWeaponStorage(string weapon, int amount);
+    void onCustomWeaponDetonation(string weapon_name, ScriptSimpleCallback callback);
     void addRoom(sf::Vector2i position, sf::Vector2i size);
     void addRoomSystem(sf::Vector2i position, sf::Vector2i size, ESystem system);
     void addDoor(sf::Vector2i position, bool horizontal);

--- a/src/spaceObjects/missiles/missileWeapon.cpp
+++ b/src/spaceObjects/missiles/missileWeapon.cpp
@@ -13,6 +13,8 @@ MissileWeapon::MissileWeapon(string multiplayer_name, const MissileWeaponData& d
     speed = 0;
     color = data.color;
 
+    std::cout << "lifeT " << lifetime << std::endl;
+
     registerMemberReplication(&target_id);
     registerMemberReplication(&target_angle);
     registerMemberReplication(&damage_multiplier);
@@ -68,6 +70,10 @@ void MissileWeapon::update(float delta)
     if (lifetime < 0)
     {
         lifeEnded();
+        if(on_detonation.isSet())
+        {   
+            on_detonation.call(P<SpaceObject>(this), string("Expired"));
+        }
         destroy();
     }
     setVelocity(sf::vector2FromAngle(getRotation()) * speed * size_speed_modifier);
@@ -89,13 +95,20 @@ void MissileWeapon::collide(Collisionable* target, float force)
     {
         return;
     }
+    
+    if(on_detonation.isSet())
+    {   
+        on_detonation.call(P<SpaceObject>(this), string("Collided"));
+    }
+    
     P<SpaceShip> ship = object;
-    if (ship && ship->isDockedWith(owner))
+    if (ship && ship->isDockedWith(owner)) //Tsht : Is this really OK ??? The missile vanishes or what ?
     {
         return;
     }
-
+    
     hitObject(object);
+    
     destroy();
 }
 

--- a/src/spaceObjects/missiles/missileWeapon.cpp
+++ b/src/spaceObjects/missiles/missileWeapon.cpp
@@ -96,17 +96,18 @@ void MissileWeapon::collide(Collisionable* target, float force)
         return;
     }
     
-    if(on_detonation.isSet())
-    {   
-        on_detonation.call(P<SpaceObject>(this), string("Collided"));
-    }
-    
     P<SpaceShip> ship = object;
-    if (ship && ship->isDockedWith(owner)) //Tsht : Is this really OK ??? The missile vanishes or what ?
+    if (ship && ship->isDockedWith(owner)) //Tsht : Is this really OK ? Do we want missiles just to ignore docked ship whatsoever, or take into account size, shields etc. ?
     {
         return;
     }
-    
+    if(on_detonation.isSet())
+    {   
+        if(ship)
+            on_detonation.call(P<SpaceObject>(this), string("HitShip"), ship);
+        else
+            on_detonation.call(P<SpaceObject>(this), string("Hit"), object);
+    }
     hitObject(object);
     
     destroy();
@@ -125,6 +126,10 @@ void MissileWeapon::takeDamage(float damage_amount, DamageInfo info)
     hull -= damage_amount;
     if (hull <= 0)
     {
+        if(on_detonation.isSet())
+        {
+            on_detonation.call(P<SpaceObject>(this), string("Destroyed"));
+        }        
         P<ExplosionEffect> e = new ExplosionEffect();
         e->setSize(getRadius());
         e->setPosition(getPosition());

--- a/src/spaceObjects/missiles/missileWeapon.h
+++ b/src/spaceObjects/missiles/missileWeapon.h
@@ -10,8 +10,6 @@ class MissileWeapon : public SpaceObject, public Updatable
 protected:
     const MissileWeaponData& data;
 
-    float lifetime; //sec
-
     bool launch_sound_played;
 
 public:
@@ -27,7 +25,9 @@ public:
     //Les deux sont cumulables, et damage_multiplier est finement customisable
     float damage_multiplier;
     EDamageType damage_type;
+    float lifetime; //sec
     //
+    ScriptSimpleCallback on_detonation;
 
     MissileWeapon(string multiplayer_name, const MissileWeaponData& data, const EDamageType &i_damage_type);
 

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -63,8 +63,6 @@ REGISTER_SCRIPT_SUBCLASS_NO_CREATE(SpaceShip, ShipTemplateBasedObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setSystemPower);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getSystemCoolant);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setSystemCoolant);
-    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getSystemHack);
-    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setSystemHack);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getSystemEffectiveness);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, getSystemRepair);
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceShip, setSystemRepair);
@@ -1362,7 +1360,7 @@ void SpaceShip::hackFinished(P<SpaceObject> source, string target)
         {
             if (target == getSystemName(ESystem(n)))
             {
-                systems[n].hacked_level = std::min(1.0f, systems[n].hacked_level + 0.5f);
+                systems[n].hacked_level = std::min(1.0f * gameGlobalInfo->hack_efficiency_ratio, (systems[n].hacked_level + 0.5f) * gameGlobalInfo->hack_efficiency_ratio);
                 return;
             }
         }

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -400,8 +400,6 @@ public:
     float getSystemCoolant(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].coolant_level; }
     void setSystemCoolant(ESystem system, float coolant) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].coolant_level = std::min(1.0f, std::max(0.0f, coolant)); }
 
-    float getSystemHack(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].hacked_level; }
-    void setSystemHack(ESystem system, float hack) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].hacked_level = std::min(3.0f, std::max(0.0f, hack)); }
     float getSystemRepair(ESystem system) { if (system >= SYS_COUNT) return 0.0; if (system <= SYS_None) return 0.0; return systems[system].repair_level; }
     void setSystemRepair(ESystem system, float repair) { if (system >= SYS_COUNT) return; if (system <= SYS_None) return; systems[system].repair_level = std::min(1.0f, std::max(0.0f, repair)); }
     float getImpulseMaxSpeed() { return impulse_max_speed; }

--- a/src/spaceObjects/spaceshipParts/weaponTube.cpp
+++ b/src/spaceObjects/spaceshipParts/weaponTube.cpp
@@ -190,6 +190,8 @@ void WeaponTube::spawnProjectile(float target_angle)
                 missile->damage_type = data.damage_type;
                 missile->color = data.color;
                 missile->category_modifier = getSizeCategoryModifier();
+                missile->lifetime = data.lifetime;
+                missile->on_detonation = data.on_detonation;
             }
             break;
         case MW_Nuke:
@@ -207,6 +209,8 @@ void WeaponTube::spawnProjectile(float target_angle)
                 missile->damage_type = data.damage_type;
                 missile->color = data.color;
                 missile->category_modifier = getSizeCategoryModifier();
+                missile->lifetime = data.lifetime;
+                missile->on_detonation = data.on_detonation;
             }
             break;
         case MW_Mine:
@@ -236,6 +240,8 @@ void WeaponTube::spawnProjectile(float target_angle)
                 missile->damage_type = data.damage_type;
                 missile->color = data.color;
                 missile->category_modifier = getSizeCategoryModifier();
+                missile->lifetime = data.lifetime;
+                missile->on_detonation = data.on_detonation;
             }
             break;
         case MW_EMP:
@@ -253,6 +259,8 @@ void WeaponTube::spawnProjectile(float target_angle)
                 missile->damage_type = data.damage_type;
                 missile->color = data.color;
                 missile->category_modifier = getSizeCategoryModifier();
+                missile->lifetime = data.lifetime;
+                missile->on_detonation = data.on_detonation;
             }
             break;
         default:


### PR DESCRIPTION
New callback "onCustomMissileWeaponDetonation" which is fired on a custom missile when destroyed 
- Because it spent its lifetime
- Because it hit something
- Because it was destroyed
Each of these possibilities are queryable from the callback. Also, if it's a ship or spaceobject, it is given to the callback