### PR TITLE
Ship modifiers

### DIFF
--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -92,8 +92,8 @@ GuiObjectTweak::GuiObjectTweak(GuiContainer* owner, ETweakType tweak_type)
         pages.push_back(new GuiShipTweakCrew(this));
         list->addEntry(tr("tab", "Crew"), "");
 
-        pages.push_back(new GuiShipTweakOxygen(this));
-        list->addEntry("Oxygene", "");
+        // pages.push_back(new GuiShipTweakOxygen(this));
+        // list->addEntry("Oxygene", "");
         //Maybe later, this would be available for NPC ships too
         pages.push_back(new GuiShipTweakDock(this));
         list->addEntry("Dock", "");

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -100,6 +100,9 @@ GuiObjectTweak::GuiObjectTweak(GuiContainer* owner, ETweakType tweak_type)
 
         pages.push_back(new GuiShipTweakMessages(this));
         list->addEntry("Messages", "");
+
+        pages.push_back(new GuiModifierTweak(this));
+        list->addEntry(tr("tab", "Modifiers"), "");
     }
 
     if (tweak_type == TW_Planet)
@@ -2345,4 +2348,79 @@ void GuiShipTweakSystemPowerFactors::onDraw(sp::RenderTarget& renderer)
     {
         system_current_power_factor[n]->setText(string(this->target->systems[n].power_factor, 1));
     }
+}
+
+GuiModifierTweak::GuiModifierTweak(GuiContainer* owner)
+    : GuiTweakPage(owner)
+{
+    // Add two columns.
+    button_col = new GuiElement(this, "LEFT_LAYOUT");
+    button_col->setPosition(50, 25, sp::Alignment::TopLeft)->setSize(300, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
+
+    information_col = new GuiElement(this, "RIGHT_LAYOUT");
+    information_col->setPosition(-25, 25, sp::Alignment::TopRight)->setSize(300, GuiElement::GuiSizeMax)->setAttribute("layout", "vertical");
+
+    (new GuiLabel(button_col, "", tr("Modifier"), 20))->setSize(GuiElement::GuiSizeMax, 30);
+    (new GuiLabel(information_col, "", tr("Information"), 20))->setSize(GuiElement::GuiSizeMax, 30);
+}
+
+void GuiModifierTweak::open(P<SpaceObject> target)
+{
+    if(!target)
+        return;
+    if(this->target)
+        return;
+    P<PlayerSpaceship> ship = target;
+    this->target = ship;
+
+    std::map<string, std::vector<string>> category_indexed_modifiers;
+    
+    for (const auto & [key, modifier] : this->target->modifiers_to_data)
+    {
+        auto list_of_modifiers_it = category_indexed_modifiers.find(modifier.category);
+        if(list_of_modifiers_it == category_indexed_modifiers.end())
+        {
+            category_indexed_modifiers.emplace(std::make_pair(modifier.category, std::vector<string>{key}));
+        }
+        else
+        {
+            list_of_modifiers_it->second.push_back(key);
+        }
+    }
+
+    for (const auto &[category, vec_of_keys] : category_indexed_modifiers)
+    {
+        (new GuiLabel(button_col, "", tr(category), 20))->setSize(GuiElement::GuiSizeMax, 30);
+        (new GuiLabel(information_col, "", "", 20))->setSize(GuiElement::GuiSizeMax, 30);
+
+        for (const auto & key : vec_of_keys)
+        {
+            PlayerSpaceship::Modifier &modifier{this->target->modifiers_to_data[key]};
+        
+            modifier_buttons.push_back(new GuiToggleButton(button_col, "", key, [this, key](bool value) {
+                    if(this->target)
+                    {
+                        if(true == value)
+                        {
+                            this->target->activateModifier(key);
+                        }
+                        else
+                        {
+                            this->target->deActivateModifier(key);
+                        }
+                    }
+                }));
+            modifier_buttons.back()->setSize(GuiElement::GuiSizeMax, 40);
+            
+            modifier_information.push_back(new GuiLabel(information_col, "", modifier.information, 20));
+            modifier_information.back()->setSize(GuiElement::GuiSizeMax, 40);
+            
+        }
+    }
+
+}
+
+void GuiModifierTweak::onDraw(sp::RenderTarget& renderer)
+{
+
 }

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -445,5 +445,26 @@ public:
     virtual void open(P<SpaceObject> target) override;
 };
 
+//Tsht
+class GuiModifierTweak : public GuiTweakPage
+{
+private:
+    P<PlayerSpaceship> target;
+
+    std::vector<GuiToggleButton*> modifier_buttons;
+    std::vector<GuiLabel*> categories;
+    std::vector<GuiLabel*> modifier_information;
+
+    GuiElement* button_col{nullptr};
+    GuiElement* information_col{nullptr};
+public:
+    GuiModifierTweak(GuiContainer* owner);
+
+    virtual void onDraw(sp::RenderTarget& renderer) override;
+
+    virtual void open(P<SpaceObject> target) override;
+};
+
+
 
 #endif//TWEAK_H

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -3020,4 +3020,26 @@ void PlayerSpaceship::onProbeUnlink(ScriptSimpleCallback callback)
     this->on_probe_unlink = callback;
 }
 
+void PlayerSpaceship::activateModifier(string name)
+{ 
+    if(!on_modifier_toggle.isSet())
+        return;
+    if (auto search = modifiers_to_data.find(name); search != modifiers_to_data.end())
+    {
+        search->second.activated = true;
+        on_modifier_toggle.call<void>(P<PlayerSpaceship>(this), name, string("activated"));
+    }
+}
+
+void PlayerSpaceship::deActivateModifier(string name)
+{ 
+    if(!on_modifier_toggle.isSet())
+        return;
+    if (auto search = modifiers_to_data.find(name); search != modifiers_to_data.end())
+    {
+        search->second.activated = false;
+        on_modifier_toggle.call<void>(P<PlayerSpaceship>(this), name, string("deactivated"));
+    }
+}
+
 #include "playerSpaceship.hpp"

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -479,6 +479,15 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     /// All SpaceObjects within this radius are dealt damage upon self-destruction.
     /// Example: ship:getSelfDestructSize()
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getSelfDestructSize);
+
+    ///Registers the modifier with the provided category, name and infos
+    ///Example : ship:registerModifier("Skill, "Name of my comp", "Upgrades hull (Engineer)")
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, registerModifier);
+    ///Registers a callback when tweak button is called for a particular modifier
+    ///Returns the name of the modifier, and "activate" to tell the action is to activate the modifier,
+    ///deactivate if the action is to deactivate the modifier
+    ///three arguments callback : self (current ship), name, desired state (activate or deactivate)
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, onModifierToggle);
 }
 
 static const int16_t CMD_TARGET_ROTATION = 0x0001;
@@ -701,7 +710,6 @@ PlayerSpaceship::PlayerSpaceship()
         registerMemberReplication(&self_destruct_code_entry_position[n]);
         registerMemberReplication(&self_destruct_code_show_position[n]);
     }
-    
     // Prepare presets initialization based on preference manager
     string power_default_presets = "";
     string power_saved_presets = "";

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -124,6 +124,15 @@ public:
 
     float energy_consumption_ratio;
 
+    //Server only
+    struct Modifier
+    {
+        string category;
+        string information;
+        bool activated{false};
+    };
+    std::map<string, Modifier> modifiers_to_data;
+
 private:
     bool on_new_player_ship_called=false;
     // Comms variables
@@ -139,15 +148,6 @@ private:
     std::vector<ShipLogEntry> ships_log_intern;
     std::vector<ShipLogEntry> ships_log_docks;
     std::vector<ShipLogEntry> ships_log_science;
-
-    //Server only
-    struct Modifier
-    {
-        string category;
-        string information;
-        bool activated{false};
-    };
-    std::map<string, Modifier> modifiers_to_data;
 
     float energy_shield_use_per_second = default_energy_shield_use_per_second;
     float energy_warp_per_second = default_energy_warp_per_second;
@@ -482,23 +482,9 @@ public:
     //Tsht
     ScriptSimpleCallback on_modifier_toggle;
     void registerModifier(string category, string name, string description) { modifiers_to_data.emplace (std::make_pair(name, Modifier{category, description, false}));}
-    void activateModifier(string name) 
-    { 
-        if (auto search = modifiers_to_data.find(name); search != modifiers_to_data.end())
-        {
-            search->second.activated = true;
-            on_modifier_toggle.call<void>(P<PlayerSpaceship>(this), name, "activate");
-        }
-    }
-    void deActivateModifier(string name)
-    { 
-       if (auto search = modifiers_to_data.find(name); search != modifiers_to_data.end())
-       {
-            search->second.activated = false;
-            on_modifier_toggle.call<void>(P<PlayerSpaceship>(this), name, "deactivate");
-       }
-    }
-
+    void activateModifier(string name);
+    void deActivateModifier(string name);
+    
     void onModifierToggle(ScriptSimpleCallback callback)
     {
         on_modifier_toggle = callback;


### PR DESCRIPTION
Ajout de la possibilité d'enregistrer des boutons dans l'interface Tweak (sous "Modifiers").
Ces boutons ont une description et un nom.

En les activant, on appelle une fonction callback en lua définie par ceci : 

///Registers the modifier with the provided category, name and infos
    ///Example : ship:registerModifier("Skill, "Name of my comp", "Upgrades hull (Engineer)")
    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, registerModifier);
    ///Registers a callback when tweak button is called for a particular modifier
    ///Returns the name of the modifier, and "activate" to tell the action is to activate the modifier,
    ///deactivate if the action is to deactivate the modifier
    ///three arguments callback : self (current ship), name, desired state (activate or deactivate)
    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, onModifierToggle);

On est ensuite appelé sur onModifierToggle avec activated ou deactivated (attention au d le commentaire dans le code n'est pas bon) quand on clique sur le bouton dans l'interface tweak.
Attention aux valeurs qu'on modifie...

